### PR TITLE
Add stream interface

### DIFF
--- a/sha256.core
+++ b/sha256.core
@@ -1,0 +1,39 @@
+CAPI=1
+
+[main]
+description = sha256 core
+
+simulators = icarus
+
+[verilog]
+src_files =
+ src/rtl/sha256_core.v
+ src/rtl/sha256_k_constants.v
+ src/rtl/sha256_w_mem.v
+ src/rtl/sha256_stream.v
+ src/rtl/sha256.v
+tb_private_src_files =
+ src/tb/tb_sha256_core.v
+ src/tb/tb_sha256_stream.v
+ src/tb/tb_sha256.v
+
+[simulator]
+toplevel = tb_sha256
+
+[icarus]
+depend = stream_utils-1.1 vlog_tb_utils-1.0
+
+[isim]
+depend = stream_utils-1.1 vlog_tb_utils-1.0
+
+[modelsim]
+depend = stream_utils-1.1 vlog_tb_utils-1.0
+
+[xsim]
+depend = stream_utils-1.1 vlog_tb_utils-1.0
+
+[parameter file]
+datatype    = file
+description = Input file to digest
+paramtype   = plusarg
+scope       = private

--- a/src/rtl/sha256_stream.v
+++ b/src/rtl/sha256_stream.v
@@ -1,0 +1,75 @@
+//======================================================================
+//
+// sha256_stream.v
+// --------
+// Top level wrapper for the SHA-256 hash function providing
+// a simple stream interface with 512 bit data access.
+//
+//
+// Author: Olof Kindgren
+// Copyright (c) 2016, Olof Kindgren
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or 
+// without modification, are permitted provided that the following 
+// conditions are met: 
+// 
+// 1. Redistributions of source code must retain the above copyright 
+//    notice, this list of conditions and the following disclaimer. 
+// 
+// 2. Redistributions in binary form must reproduce the above copyright 
+//    notice, this list of conditions and the following disclaimer in 
+//    the documentation and/or other materials provided with the 
+//    distribution. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//======================================================================
+
+module sha256_stream
+  (input 	  clk,
+   input 	  rst,
+   input [511:0]  s_tdata_i,
+   input 	  s_tlast_i,
+   input 	  s_tvalid_i,
+   output 	  s_tready_o,
+   output [255:0] digest_o,
+   output 	  digest_valid_o);
+
+   reg 		  first_block;
+
+   always @(posedge clk) begin
+      if (s_tvalid_i & s_tready_o)
+	first_block <= s_tlast_i;
+
+      if (rst) begin
+	 first_block <= 1'b1;
+      end
+   end
+   
+   sha256_core core
+     (.clk     (clk),
+      .reset_n (~rst),
+
+      .init(s_tvalid_i & first_block),
+      .next(s_tvalid_i & !first_block),
+
+      .block(s_tdata_i),
+
+      .ready(s_tready_o),
+
+      .digest       (digest_o),
+      .digest_valid (digest_valid_o));
+
+endmodule

--- a/src/scripts/pad.py
+++ b/src/scripts/pad.py
@@ -1,0 +1,30 @@
+import os
+import shutil
+import struct
+import sys
+
+out_filename = sys.argv[1]+".padded"
+shutil.copyfile(sys.argv[1], out_filename)
+with open(out_filename,'ab') as f:
+    f.seek(0, os.SEEK_END)
+    size = f.tell()
+    print(size)
+    #Add padding word to end of file
+    f.write(bytearray([0x80]))
+
+    #Calculate number of padding zeroes
+    # = File size rounded up to next 512-byte block
+    # minues space for padding start byte (0x80)
+    # and 64-bit (8 byte) length word
+    zeroes = 64 - (size % 64) - 1 - 8
+    if zeroes < 0:
+        zeroes += 64
+    
+    print(zeroes)
+    f.write(bytearray([0]*zeroes))
+    #sizeword = (size % 64)*8
+    #if sizeword == 0:
+    #    sizeword = 64*8
+    sizeword = size*8
+    f.write(struct.pack('>Q', sizeword))
+

--- a/src/tb/tb_sha256.v
+++ b/src/tb/tb_sha256.v
@@ -162,7 +162,7 @@ module tb_sha256();
   //
   // Dump the state of the dump when needed.
   //----------------------------------------------------------------
-  task dump_dut_state();
+  task dump_dut_state;
     begin
       $display("State of DUT");
       $display("------------");
@@ -206,7 +206,7 @@ module tb_sha256();
   //
   // Toggles reset to force the DUT into a well defined state.
   //----------------------------------------------------------------
-  task reset_dut();
+  task reset_dut;
     begin
       $display("*** Toggle reset.");
       tb_reset_n = 0;
@@ -222,7 +222,7 @@ module tb_sha256();
   // Initialize all counters and testbed functionality as well
   // as setting the DUT inputs to defined values.
   //----------------------------------------------------------------
-  task init_sim();
+  task init_sim;
     begin
       cycle_ctr = 32'h00000000;
       error_ctr = 32'h00000000;
@@ -243,7 +243,7 @@ module tb_sha256();
   //
   // Display the accumulated test results.
   //----------------------------------------------------------------
-  task display_test_result();
+  task display_test_result;
     begin
       if (error_ctr == 0)
         begin
@@ -268,7 +268,7 @@ module tb_sha256();
   // when the dut is actively processing and will in fact at some
   // point set the flag.
   //----------------------------------------------------------------
-  task wait_ready();
+  task wait_ready;
     begin
       read_data = 0;
       
@@ -362,7 +362,7 @@ module tb_sha256();
   //
   // Read the name and version from the DUT.
   //----------------------------------------------------------------
-  task check_name_version();
+  task check_name_version;
     reg [31 : 0] name0;
     reg [31 : 0] name1;
     reg [31 : 0] version;
@@ -390,7 +390,7 @@ module tb_sha256();
   // Read the digest in the dut. The resulting digest will be
   // available in the global variable digest_data.
   //----------------------------------------------------------------
-  task read_digest();
+  task read_digest;
     begin
       read_word(ADDR_DIGEST0);
       digest_data[255 : 224] = read_data;

--- a/src/tb/tb_sha256_core.v
+++ b/src/tb/tb_sha256_core.v
@@ -126,7 +126,7 @@ module tb_sha256_core();
   //
   // Dump the state of the dump when needed.
   //----------------------------------------------------------------
-  task dump_dut_state();
+  task dump_dut_state;
     begin
       $display("State of DUT");
       $display("------------");
@@ -181,7 +181,7 @@ module tb_sha256_core();
   //
   // Toggle reset to put the DUT into a well known state.
   //----------------------------------------------------------------
-  task reset_dut();
+  task reset_dut;
     begin
       $display("*** Toggle reset.");
       tb_reset_n = 0;
@@ -197,7 +197,7 @@ module tb_sha256_core();
   // Initialize all counters and testbed functionality as well
   // as setting the DUT inputs to defined values.
   //----------------------------------------------------------------
-  task init_sim();
+  task init_sim;
     begin
       cycle_ctr = 0;
       error_ctr = 0;
@@ -218,7 +218,7 @@ module tb_sha256_core();
   //
   // Display the accumulated test results.
   //----------------------------------------------------------------
-  task display_test_result();
+  task display_test_result;
     begin
       if (error_ctr == 0)
         begin
@@ -241,7 +241,7 @@ module tb_sha256_core();
   // when the dut is actively processing and will in fact at some
   // point set the flag.
   //----------------------------------------------------------------
-  task wait_ready();
+  task wait_ready;
     begin
       while (!tb_ready)
         begin

--- a/src/tb/tb_sha256_stream.v
+++ b/src/tb/tb_sha256_stream.v
@@ -120,7 +120,7 @@ module tb_sha256_stream();
 
       c = $fread(word, f);
       while (c) begin
-	 writer.write_word(word, 1'b0);
+	 writer.write_word(word);
 	 c = $fread(word, f);
       end
       filesize = $ftell(f);

--- a/src/tb/tb_sha256_stream.v
+++ b/src/tb/tb_sha256_stream.v
@@ -1,0 +1,135 @@
+//======================================================================
+//
+// tb_sha256_stream.v
+// -----------
+// Testbench for the SHA-256 stream interface wrapper.
+//
+//
+// Author: Olof Kindgren
+// Copyright (c) 2016, Olof Kindgren
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or
+// without modification, are permitted provided that the following
+// conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in
+//    the documentation and/or other materials provided with the
+//    distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//======================================================================
+
+module tb_sha256_stream();
+
+   vlog_tb_utils vtu();
+
+   parameter DW = 32;
+
+   reg clk = 1'b1;
+   reg rst = 1'b1;
+
+   wire [DW-1:0] tdata;
+   wire 	 tvalid;
+   wire 	 tready;
+
+   wire [511:0]  tdata_resized;
+   wire 	 tvalid_resized;
+   wire 	 tready_resized;
+
+   wire [255:0]  digest;
+   wire 	 digest_valid;
+
+   always #5 clk <= !clk;
+   initial #20 rst = 1'b0;
+
+   stream_writer
+     #(.WIDTH (DW),
+       .MAX_BLOCK_SIZE (1))
+   writer
+     (.clk (clk),
+      .stream_m_data_o  (tdata),
+      .stream_m_valid_o (tvalid),
+      .stream_m_ready_i (tready));
+
+   stream_upsizer
+     #(.DW_IN (DW),
+       .SCALE (512/DW),
+       .BIG_ENDIAN(1))
+   upsizer
+     (.clk (clk),
+      .rst (rst),
+      //Slave Interface
+      .s_data_i  (tdata),
+      .s_valid_i (tvalid),
+      .s_ready_o (tready),
+      //Master Interface
+      .m_data_o  (tdata_resized),
+      .m_valid_o (tvalid_resized),
+      .m_ready_i (tready_resized));
+
+   sha256_stream dut
+     (.clk            (clk),
+      .rst            (rst),
+      .s_tdata_i      (tdata_resized),
+      .s_tlast_i      (1'b0),
+      .s_tvalid_i     (tvalid_resized),
+      .s_tready_o     (tready_resized),
+      .digest_o       (digest),
+      .digest_valid_o (digest_valid));
+
+   integer 	 digested_blocks = 0;
+
+   always @(posedge digest_valid)
+     digested_blocks = digested_blocks + 1;
+
+   reg [DW-1:0] word;
+
+   reg [1024*8-1:0] filename = "";
+
+   integer 	    filesize;
+   integer 	    f;
+   integer 	    c;
+
+   initial begin
+      if (!$value$plusargs("file=%s", filename)) begin
+	 $display("No file specified");
+	 $finish;
+      end
+
+      @(negedge rst);
+      @(posedge clk);
+
+      f = $fopen(filename, "rb");
+
+      c = $fread(word, f);
+      while (c) begin
+	 writer.write_word(word, 1'b0);
+	 c = $fread(word, f);
+      end
+      filesize = $ftell(f);
+      $fclose(f);
+
+      while(digested_blocks*64 < filesize)
+	@(posedge clk);
+      $display("%h", digest);
+      $finish;
+   end
+
+endmodule

--- a/src/tb/tb_sha256_w_mem.v
+++ b/src/tb/tb_sha256_w_mem.v
@@ -129,7 +129,7 @@ module tb_sha256_w_mem();
   //
   // Dump the current state of all W registers.
   //----------------------------------------------------------------
-  task dump_w_state();
+  task dump_w_state;
     begin
       $display("W state:");
       
@@ -154,7 +154,7 @@ module tb_sha256_w_mem();
   //----------------------------------------------------------------
   // reset_dut
   //----------------------------------------------------------------
-  task reset_dut();
+  task reset_dut;
     begin
       $display("*** Toggle reset.");
       tb_reset_n = 0;
@@ -167,7 +167,7 @@ module tb_sha256_w_mem();
   //----------------------------------------------------------------
   // init_sim
   //----------------------------------------------------------------
-  task init_sim();
+  task init_sim;
     begin
       $display("*** Simulation init.");
       tb_clk = 0;
@@ -186,7 +186,7 @@ module tb_sha256_w_mem();
   // Test that W scheduling happens and work correctly.
   // Note: Currently not a self checking test case.
   //----------------------------------------------------------------
-  task test_w_schedule();
+  task test_w_schedule;
     begin
       $display("*** Test of W schedule processing. --");
       tb_block = 512'h61626380000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000018;


### PR DESCRIPTION
This series fixes some syntax errors and adds a stream interface

The stream interface tb has dependencies on external components and uses FuseSoC to pull them in. It can be invoked by running "make stream" from the toolruns directory to create a random file and check it. To digest any existing file, run "FILE=/path/to/file make stream"
