### PR TITLE
Fix typo in model: sha256.py

### DIFF
--- a/src/model/python/sha256.py
+++ b/src/model/python/sha256.py
@@ -96,7 +96,7 @@ class SHA256():
 
 
     def init(self):
-        if self.mode == "sha356":
+        if self.mode == "sha256":
             self.H = [0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
                       0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19]
         else:


### PR DESCRIPTION
mode was set improperly in the python model